### PR TITLE
fixed cave bug and deactivated sandboxing

### DIFF
--- a/Engine/RXCard.m
+++ b/Engine/RXCard.m
@@ -230,7 +230,7 @@
           NSMutableArray* cases = [NSMutableArray array];
           [cases addObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:0], @"value", block0, @"block" , nil]];
           [cases addObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:1], @"value", block1, @"block" , nil]];
-          for(uint16_t casei = 2; casei < 6; casei++) {
+          for(uint16_t casei = 2; casei <= 6; casei++) {
             [cases addObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:casei], @"value", block_other, @"block" , nil]];
           }
           

--- a/Engine/RXCard.m
+++ b/Engine/RXCard.m
@@ -207,6 +207,50 @@
       [comp release];
     }
   }
+  
+  // WORKAROUND: there is a serious bug in the steam (and probably the DVD) edition's jspit 255 (112089)
+  // which causes it to load the card open script of the CD edition's jspit 255 (111729) (see Riven cave bug/glitch).
+  // this would cause the engine to crash, since the script would try to activate inexistent BLST and PLST records.
+  else if([_descriptor isCardWithRMAP:112089 stackName:@"jspit"]) {
+    NSDictionary* open_card_program = [[_card_scripts objectForKey:RXCardOpenScriptKey] objectAtIndex:0];
+    if(open_card_program) {
+      RXScriptCompiler* comp = [[RXScriptCompiler alloc] initWithCompiledScript:open_card_program];
+      NSMutableArray* dp = [comp decompiledScript];
+      
+      NSDictionary* opcode = [dp firstObject];
+      if(opcode && RX_OPCODE_COMMAND_EQ(opcode, RX_COMMAND_BRANCH)) {
+        NSDictionary* case0 = [[opcode objectForKey:@"cases"] objectAtIndex:0];
+        if([[case0 objectForKey:@"block"] count] == 6) {
+          // scrap loaded script and construct our own:
+          
+          NSArray* block0 = [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:RX_COMMAND_ACTIVATE_PLST], @"command", [NSArray arrayWithObject:[NSNumber numberWithUnsignedShort:1]], @"args", nil]];
+          NSArray* block1 = [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:RX_COMMAND_ACTIVATE_PLST], @"command", [NSArray arrayWithObject:[NSNumber numberWithUnsignedShort:2]], @"args", nil]];
+          NSArray* block_other = [NSArray arrayWithObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:RX_COMMAND_ACTIVATE_PLST], @"command", [NSArray arrayWithObject:[NSNumber numberWithUnsignedShort:3]], @"args", nil]];
+          
+          NSMutableArray* cases = [NSMutableArray array];
+          [cases addObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:0], @"value", block0, @"block" , nil]];
+          [cases addObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:1], @"value", block1, @"block" , nil]];
+          for(uint16_t casei = 2; casei < 6; casei++) {
+            [cases addObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:casei], @"value", block_other, @"block" , nil]];
+          }
+          
+          opcode = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:RX_COMMAND_BRANCH], @"command", [NSNumber numberWithUnsignedShort:20], @"variable", cases, @"cases", nil];
+          
+          NSArray *program = [NSArray arrayWithObject:opcode];
+          
+          
+          [comp setDecompiledScript:program];
+          NSMutableDictionary* mutable_scripts = [_card_scripts mutableCopy];
+          [mutable_scripts setObject:[NSArray arrayWithObject:[comp compiledScript]] forKey:RXCardOpenScriptKey];
+          
+          [_card_scripts release];
+          _card_scripts = mutable_scripts;
+          
+          [comp release];
+        }
+      }
+    }
+  }
 }
 
 - (void)_loadPictures
@@ -501,6 +545,70 @@
     // WORKAROUND: tweak hotspot "open" on bspit 163 (85071) to have the open-hand cursor
     else if ([_descriptor isCardWithRMAP:85071 stackName:@"bspit"] && hotspotName && [hotspotName isEqualToString:@"open"]) {
       hspt_record->mouse_cursor = RX_CURSOR_OPEN_HAND;
+    }
+    
+    // WORKAROUND: there is a serious bug in the steam (and probably the DVD) edition's jspit 255 (112089)
+    // which causes it to load the hotspots of the CD edition's jspit 255 (111729).
+    else if ([_descriptor isCardWithRMAP:112089 stackName:@"jspit"] && [_descriptor ID] == 255) {
+      if(hotspotName && ([hotspotName isEqualToString:@"afr"] || [hotspotName isEqualToString:@"afl"])) {
+        // for these only the arg for the goto card call needs to be fixed
+        NSDictionary* program = [[hotspot_scripts objectForKey:RXMouseDownScriptKey] objectAtIndex:0];
+        RXScriptCompiler* comp = [[RXScriptCompiler alloc] initWithCompiledScript:program];
+        NSMutableArray* dp = [comp decompiledScript];
+        
+        NSMutableDictionary* opcode = [dp lastObject];
+        NSMutableArray *args = [opcode objectForKey:@"args"];
+        [args replaceObjectAtIndex:0 withObject:[NSNumber numberWithUnsignedShort:254]];
+        [comp setDecompiledScript:dp];
+        
+        NSMutableDictionary* mutable_script = [hotspot_scripts mutableCopy];
+        [mutable_script setObject:[NSArray arrayWithObject:[comp compiledScript]] forKey:RXMouseDownScriptKey];
+        
+        [hotspot_scripts release];
+        hotspot_scripts = mutable_script;
+        
+        [comp release];
+      } else if (hotspotName && [hotspotName isEqualToString:@"light"]) {
+        // this one is completely wrong
+        
+        // fix name
+        hotspotName = @"forward";
+        
+        // fix rect
+        hspt_record->rect.left = 156;
+        hspt_record->rect.top = 30;
+        hspt_record->rect.right = 427;
+        hspt_record->rect.bottom = 392;
+        
+        // fix id
+        hspt_record->blst_id = 3;
+        
+        // fix cursor
+        NSDictionary* program = [[hotspot_scripts objectForKey:RXMouseInsideScriptKey] objectAtIndex:0];
+        RXScriptCompiler* comp = [[RXScriptCompiler alloc] initWithCompiledScript:program];
+        NSMutableArray* dp = [comp decompiledScript];
+        
+        NSMutableDictionary* opcode = [dp lastObject];
+        NSMutableArray *args = [opcode objectForKey:@"args"];
+        [args replaceObjectAtIndex:0 withObject:[NSNumber numberWithUnsignedShort:RX_CURSOR_FORWARD]];
+        [comp setDecompiledScript:dp];
+        
+        NSMutableDictionary* mutable_script = [hotspot_scripts mutableCopy];
+        [mutable_script setObject:[NSArray arrayWithObject:[comp compiledScript]] forKey:RXMouseInsideScriptKey];
+        
+        // replace mouse down program
+        NSDictionary* transition = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:RX_COMMAND_SCHEDULE_TRANSITION], @"command", [NSArray arrayWithObject:[NSNumber numberWithUnsignedShort:16]], @"args", nil];
+        NSDictionary* goto_card = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:RX_COMMAND_GOTO_CARD], @"command", [NSArray arrayWithObject:[NSNumber numberWithUnsignedShort:253]], @"args", nil];
+        dp = [NSMutableArray arrayWithObjects:transition, goto_card, nil];
+        
+        [comp setDecompiledScript:dp];
+        [mutable_script setObject:[NSArray arrayWithObject:[comp compiledScript]] forKey:RXMouseDownScriptKey];
+        
+        [hotspot_scripts release];
+        hotspot_scripts = mutable_script;
+        
+        [comp release];
+      }
     }
 
     // allocate the hotspot object

--- a/Riven X.entitlements
+++ b/Riven X.entitlements
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.downloads.read-write</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-</dict>
+<dict/>
 </plist>

--- a/rivenx.xcodeproj/project.pbxproj
+++ b/rivenx.xcodeproj/project.pbxproj
@@ -1322,8 +1322,21 @@
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = MacStorm;
 				TargetAttributes = {
+					3149598E0E327B2D00E49C83 = {
+						DevelopmentTeam = 7K63C7SQ45;
+					};
+					31ADC95114ADA128004FB4AD = {
+						DevelopmentTeam = 7K63C7SQ45;
+						ProvisioningStyle = Automatic;
+					};
 					31F3093208BE43C100417394 = {
-						DevelopmentTeam = 4YFS4VAABW;
+						DevelopmentTeam = 7K63C7SQ45;
+						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.Sandbox = {
+								enabled = 0;
+							};
+						};
 					};
 				};
 			};
@@ -1774,8 +1787,9 @@
 		314959910E327B2E00E49C83 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 7K63C7SQ45;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
@@ -1803,6 +1817,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 7K63C7SQ45;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
@@ -1830,6 +1845,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 7K63C7SQ45;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
@@ -1917,7 +1933,9 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7K63C7SQ45;
 				GCC_DYNAMIC_NO_PIC = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/xz/$(CURRENT_ARCH)";
@@ -1927,6 +1945,7 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -1936,7 +1955,9 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7K63C7SQ45;
 				GCC_DYNAMIC_NO_PIC = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/xz/$(CURRENT_ARCH)";
@@ -1946,6 +1967,7 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 			};
 			name = "Beta Release";
@@ -1955,7 +1977,9 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7K63C7SQ45;
 				GCC_DYNAMIC_NO_PIC = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/xz/$(CURRENT_ARCH)";
@@ -1965,6 +1989,7 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -2311,9 +2336,10 @@
 				APPCAST_URL = "http://www.devklog.net/software/rivenx/rivenx.xml";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_ENTITLEMENTS = "Riven X.entitlements";
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 7K63C7SQ45;
 				GCC_PREFIX_HEADER = RXBase.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -2325,6 +2351,7 @@
 				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
 				PLIST_FILE_OUTPUT_FORMAT = binary;
 				PRODUCT_NAME = "Riven X";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = "Beta Release";
@@ -2416,9 +2443,10 @@
 				APPCAST_URL = "http://www.devklog.net/software/rivenx/rivenx.xml";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_ENTITLEMENTS = "Riven X.entitlements";
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 7K63C7SQ45;
 				GCC_PREFIX_HEADER = RXBase.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -2430,6 +2458,7 @@
 				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
 				PLIST_FILE_OUTPUT_FORMAT = binary;
 				PRODUCT_NAME = "Riven X";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -2440,9 +2469,10 @@
 				APPCAST_URL = "http://www.devklog.net/software/rivenx/rivenx.xml";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_ENTITLEMENTS = "Riven X.entitlements";
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 7K63C7SQ45;
 				GCC_PREFIX_HEADER = RXBase.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -2454,6 +2484,7 @@
 				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
 				PLIST_FILE_OUTPUT_FORMAT = binary;
 				PRODUCT_NAME = "Riven X";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;


### PR DESCRIPTION
I patched a bug that that occurs in the steam version and that causes the engine to crash when trying to turn around at the end of the cave on jungle island (see Riven cave glitch/bug).

I also deactivated sandboxing, because it prevents the application to use any preexisting installation which is not located in the download folder.

Edit: fixed minor bug in the replacement script